### PR TITLE
Replace the deprecated Crashlytics Beta Distribution by Firebase's

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Types of changes
+
+_Choose one_
+
+- Bugfix
+- New feature
+- Chore
+- Unit tests
+- Refactoring
+- Release
+
+## Description of the proposed changes
+
+_Please describe your changes here to help reviewer, explaining the reason for this PR, and also you can include screenshots if your change is UI related. Please remember to include the type of change in your title (Bugfix, Chore, Feature, Refactoring)_.


### PR DESCRIPTION
## Types of changes

- Chore

## Description of the proposed changes

Since Crashlytics no longer exists, we are adopting a new tool to distribute our mobile apps internally pointing to our staging server. The lane created requires some attributes to work, given that the apps built for this kind of distributions have a different schema, thus their config don't come from the regular config files (Matchfile, Gymfile, etc).

Example of usage:

```ruby
firebase_beta(
  app_identifier: "com.loadsmart.LiveLoads.beta", 
  configuration: "Beta", 
  firebase_group: "liveloads-beta-testers",
  scheme: "liveloads"
)
```