### PR TITLE
Decouple versioning logic from the beta deploy lane

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -74,6 +74,8 @@ platform :ios do
     bump
     build_app(scheme: scheme, configuration: configuration, export_method: "ad-hoc")
     firebase_app_distribution(app: firebase_app, groups: firebase_group)
+    commit_version if options[:commit]
+    push_to_git_remote if options[:push]
   end
 
   desc "Submit a new Beta version to Testflight"

--- a/Fastfile
+++ b/Fastfile
@@ -74,8 +74,6 @@ platform :ios do
     bump
     build_app(scheme: scheme, configuration: configuration, export_method: "ad-hoc")
     firebase_app_distribution(app: firebase_app, groups: firebase_group)
-    commit_version
-    push_to_git_remote
   end
 
   desc "Submit a new Beta version to Testflight"


### PR DESCRIPTION
## Types of changes

- Chore

## Description of the proposed changes

This PR removes the commit/push steps from the beta deploy lane. This has been done in order to give the control of the versioning to the user of this lib.