### PR TITLE
chore: include roadrunners as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @loadsmart/mobile
+*   @loadsmart/roadrunners @loadsmart/mobile

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,4 +11,4 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: mobile
+  owner: roadrunners


### PR DESCRIPTION
## Types of changes

- Chore

## Description of the proposed changes

Setting @loadsmart/roadrunners  as owner of repository.
